### PR TITLE
     #5 Avoid NULL pointer

### DIFF
--- a/map_server/src/map_saver.cpp
+++ b/map_server/src/map_saver.cpp
@@ -91,6 +91,11 @@ class MapGenerator
       ROS_INFO("Writing map occupancy data to %s", mapmetadatafile.c_str());
       FILE* yaml = fopen(mapmetadatafile.c_str(), "w");
 
+      if (!yaml)
+      {
+        ROS_ERROR("Couldn't save map file to %s", mapmetadatafile.c_str());
+        return;
+      }
 
       /*
 resolution: 0.100000


### PR DESCRIPTION
     Correct the indication by the static analysis tool.
     Avoid NULL pointer dereferencing.