### PR TITLE
     #4 Avoid NULL pointer

### DIFF
--- a/amcl/src/amcl/map/map.c
+++ b/amcl/src/amcl/map/map.c
@@ -40,6 +40,9 @@ map_t *map_alloc(void)
   map_t *map;
 
   map = (map_t*) malloc(sizeof(map_t));
+  assert(map);
+  if (map == NULL)
+    return map;
 
   // Assume we start at (0, 0)
   map->origin_x = 0;

--- a/amcl/src/amcl/map/map_store.c
+++ b/amcl/src/amcl/map/map_store.c
@@ -81,6 +81,13 @@ int map_load_occ(map_t *map, const char *filename, double scale, int negate)
     map->size_x = width;
     map->size_y = height;
     map->cells = calloc(width * height, sizeof(map->cells[0]));
+    assert(map->cells);
+    if (map->cells == NULL)
+    {
+      fprintf(stderr, "Failed at memory allocate");
+      fclose(file);
+      return -1;
+    }
   }
   else
   {


### PR DESCRIPTION
     Correct the indication by the static analysis tool.
     Avoid NULL pointer dereferencing.