### PR TITLE
 #14 free memory

### DIFF
--- a/navfn/src/navtest.cpp
+++ b/navfn/src/navtest.cpp
@@ -199,6 +199,8 @@ int main(int argc, char **argv)
     }
   }
 
+  free(cmap);
+
   return 0;
 }
 


### PR DESCRIPTION
 Correct the indication by the static analysis tool.
 Freeing memory allocated by malloc.