### PR TITLE
 #12 Buffer overflow

### DIFF
--- a/amcl/src/amcl/pf/eig3.c
+++ b/amcl/src/amcl/pf/eig3.c
@@ -3,6 +3,7 @@
    domain Java Matrix library JAMA. */
 
 #include <math.h>
+#include <assert.h>
 
 #ifndef MAX
 #define MAX(a, b) ((a)>(b)?(a):(b))
@@ -169,6 +170,10 @@ static void tql2(double V[n][n], double d[n], double e[n]) {
         break;
       }
       m++;
+    }
+    assert(m < n);
+    if( m >= n ){
+      return;
     }
 
     // If m == l, d[l] is an eigenvalue,

--- a/amcl/src/amcl/pf/pf_kdtree.c
+++ b/amcl/src/amcl/pf/pf_kdtree.c
@@ -265,6 +265,10 @@ pf_kdtree_node_t *pf_kdtree_insert_node(pf_kdtree_t *self, pf_kdtree_node_t *par
         }
       }
       assert(node->pivot_dim >= 0);
+      if (node->pivot_dim < 0)
+      {
+        return node;
+      }
 
       node->pivot_value = (key[node->pivot_dim] + node->key[node->pivot_dim]) / 2.0;
 


### PR DESCRIPTION
 Correct the indication by the static analysis tool.
 Avoid access outside the bounds of the array.
 This is a path that cannot be passed in normal operation.