### PR TITLE
 #17 file close

### DIFF
--- a/navfn/src/navtest.cpp
+++ b/navfn/src/navtest.cpp
@@ -302,5 +302,6 @@ readPGM(const char *fname, int *width, int *height, bool raw)
   pgm_freerow(row);
   *width = ncols;
   *height = nrows;
+  fclose(pgmfile);
   return cmap;
 }


### PR DESCRIPTION
 Correct the indication by the static analysis tool.
 Correction of return without closing the file.