### PR TITLE
 #46 Division_by_zero

### DIFF
--- a/global_planner/src/planner_core.cpp
+++ b/global_planner/src/planner_core.cpp
@@ -421,7 +421,11 @@ void GlobalPlanner::publishPotential(float* potential)
         if (potential_array_[i] >= POT_HIGH) {
             grid.data[i] = -1;
         } else
-            grid.data[i] = potential_array_[i] * publish_scale_ / max;
+            if (fabs(max) < DBL_EPSILON) {
+              grid.data[i] = -1;
+            }else{
+              grid.data[i] = potential_array_[i] * publish_scale_ / max;
+            }
     }
     potential_pub_.publish(grid);
 }


### PR DESCRIPTION
 Correct the indication by the static analysis tool.
 Avoid division by zero.