### PR TITLE
 #3  Avoid NULL pointer

### DIFF
--- a/costmap_2d/plugins/inflation_layer.cpp
+++ b/costmap_2d/plugins/inflation_layer.cpp
@@ -161,6 +161,7 @@ void InflationLayer::updateBounds(double robot_x, double robot_y, double robot_y
 
 void InflationLayer::onFootprintChanged()
 {
+  boost::unique_lock < boost::recursive_mutex > lock(*inflation_access_);
   inscribed_radius_ = layered_costmap_->getInscribedRadius();
   cell_inflation_radius_ = cellDistance(inflation_radius_);
   computeCaches();
@@ -347,8 +348,7 @@ void InflationLayer::deleteKernels()
       if (cached_distances_[i])
         delete[] cached_distances_[i];
     }
-    if (cached_distances_)
-      delete[] cached_distances_;
+    delete[] cached_distances_;
     cached_distances_ = NULL;
   }
 


### PR DESCRIPTION
 Correct the indication by the static analysis tool.
 Avoid NULL pointer dereferencing.
 Fixed non-thread-safe implementation.