### PR TITLE
 #83 Fix_error_handling

### DIFF
--- a/amcl/src/amcl/map/map_store.c
+++ b/amcl/src/amcl/map/map_store.c
@@ -82,10 +82,9 @@ int map_load_occ(map_t *map, const char *filename, double scale, int negate)
     map->size_x = width;
     map->size_y = height;
     map->cells = calloc(width * height, sizeof(map->cells[0]));
-    assert(map->cells);
     if (map->cells == NULL)
     {
-      fprintf(stderr, "Failed at memory allocate");
+      fprintf(stderr, "Failed at memory allocate:(width,height)=(%d,%d)\n", width, height);
       fclose(file);
       return -1;
     }


### PR DESCRIPTION
 Added an assert operation in the previous fix.
 However, it was more appropriate to output an error message
 than to process with assert, so we reviewed it.