### PR TITLE
 #20 infinite loops

### DIFF
--- a/move_base/include/move_base/move_base.h
+++ b/move_base/include/move_base/move_base.h
@@ -215,7 +215,7 @@ namespace move_base {
       std::vector<geometry_msgs::PoseStamped>* controller_plan_;
 
       //set up the planner's thread
-      bool runPlanner_;
+      volatile bool runPlanner_;
       boost::recursive_mutex planner_mutex_;
       boost::condition_variable_any planner_cond_;
       geometry_msgs::PoseStamped planner_goal_;


### PR DESCRIPTION
 Correct the indication by the static analysis tool.
 Avoid infinite loops caused by optimization.